### PR TITLE
Fix UI bug on Landing page

### DIFF
--- a/UI/css/main.css
+++ b/UI/css/main.css
@@ -96,7 +96,7 @@ footer {
 #landingPageHeroImage {
     background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url("../img/bg-hero.jpg");
     width: 100%;
-    height: 100vh;
+    height: 70vh;
     background-size: cover;
     background-position: center center;
     background-repeat: no-repeat;

--- a/UI/css/queries.css
+++ b/UI/css/queries.css
@@ -19,3 +19,17 @@
 @media only screen and (max-width: 480px) {
 
 }
+
+/* Media queries for small phones from 0 to 320px */
+@media only screen and (max-width: 320px) {
+    
+    /* Landing page headerNav */
+    #headerNav {
+        font-size: 90%;
+    }
+
+    /* Hero image text */
+    #landingPageHeroImage h1 { font-size: 100%; }
+
+    #landingPageHeroImage p { font-size: 70%; }
+}


### PR DESCRIPTION
The previous height of 100vh for the heroImageSection made the header
and footer disappear from view.
A uniform height of 70vh is now used for the section in both landing
page and sign up page.
Also had to apply media queries at width 320px for landing page
[Fixes #162687558]