### PR TITLE
Rename describe blocks for all test suites

### DIFF
--- a/test/contollers/meetup.test.js
+++ b/test/contollers/meetup.test.js
@@ -6,7 +6,7 @@ chai.use(require('chai-http'));
 
 const should = chai.should();
 
-describe('create meetup record', () => {
+describe('POST /api/v1/meetups', () => {
   // Sample valid meetup request data
   const meetupRecord = {
     location: 'Ikeja',
@@ -58,7 +58,7 @@ describe('create meetup record', () => {
 });
 
 
-describe('get all meetup records', () => {
+describe('GET /api/v1/meetups', () => {
   // Sample valid meetup request data
   const meetupRecord = {
     location: 'Radison Blue',
@@ -98,7 +98,7 @@ describe('get all meetup records', () => {
   });
 });
 
-describe('get specific meetup record', () => {
+describe('GET /api/v1/meetups/:id', () => {
   // Sample valid meetup request data
   const meetupRecord = {
     location: 'Ogba',
@@ -146,7 +146,7 @@ describe('get specific meetup record', () => {
   });
 });
 
-describe('get upcoming meetups', () => {
+describe('GET /api/v1/meetups/upcoming', () => {
   let upcomingMeetups;
   before((done) => {
     chai.request(app)
@@ -162,7 +162,7 @@ describe('get upcoming meetups', () => {
   });
 });
 
-describe('rsvp to meetup', () => {
+describe('POST /api/v1/meetups/:id/rsvp', () => {
   describe('request', () => {
     let meetupRecordResponse;
     // Sample valid meetup request data

--- a/test/contollers/question.test.js
+++ b/test/contollers/question.test.js
@@ -7,7 +7,7 @@ chai.use(require('chai-http'));
 
 const should = chai.should();
 
-describe('post question', () => {
+describe('POST /api/v1/questions', () => {
   // Sample valid question request data
   const questionRecord = {
     createdBy: uuid(),
@@ -57,7 +57,7 @@ describe('post question', () => {
   });
 });
 
-describe('PATCH /questions/:questionID/upvote', () => {
+describe('PATCH /api/v1/questions/:id/upvote', () => {
   it('should respond with error if question does not exist', (done) => {
     const fakeQuestionID = 982;
     chai.request(app)
@@ -103,7 +103,7 @@ describe('PATCH /questions/:questionID/upvote', () => {
   });
 });
 
-describe('PATCH /questions/:questionID/downvote', () => {
+describe('PATCH /api/v1/questions/:id/downvote', () => {
   it('should respond with error if question does not exist', (done) => {
     const fakeQuestionID = 982;
     chai.request(app)


### PR DESCRIPTION
After renaming, it looks like so:
describe('POST /meetups', ...);

This would allow for better readability